### PR TITLE
add missing control register configuration functions

### DIFF
--- a/functions/MLX90640_API.c
+++ b/functions/MLX90640_API.c
@@ -391,6 +391,60 @@ int MLX90640_GetCurMode(uint8_t slaveAddr)
 
 //------------------------------------------------------------------------------
 
+int MLX90640_SetSubPageRepeat(uint8_t slaveAddr, uint8_t subPageRepeat){
+    uint16_t controlRegister1;
+    int value;
+    int error;
+
+    value = (subPageRepeat & 0x01)<<3;
+
+    error = MLX90640_I2CRead(slaveAddr, MLX90640_CTRL_REG, 1, &controlRegister1);
+    if (error == 0){
+        value = (controlRegister1 & ~MLX90640_CTRL_SUBPAGE_REPEAT_MASK) | value;
+        error = MLX90640_I2CWrite(slaveAddr, MLX90640_CTRL_REG, value);
+    }
+
+    return error;
+}
+
+//------------------------------------------------------------------------------
+
+int MLX90640_SetSubPage(uint8_t slaveAddr, uint8_t subPage){
+    uint16_t controlRegister1;
+    int value;
+    int error;
+
+    value = (subPage & 0x01)<<4;
+
+    error = MLX90640_I2CRead(slaveAddr, MLX90640_CTRL_REG, 1, &controlRegister1);
+    if (error == 0){
+        value = (controlRegister1 &  ~MLX90640_CTRL_SUBPAGE_MASK) | value;
+        error = MLX90640_I2CWrite(slaveAddr, MLX90640_CTRL_REG, value);
+    }
+
+    return error;
+}
+
+//------------------------------------------------------------------------------
+
+int MLX90640_SetDeviceMode(uint8_t slaveAddr, uint8_t deviceMode){
+    uint16_t controlRegister1;
+    int value;
+    int error;
+
+    value = (deviceMode & 0x01)<<4;
+
+    error = MLX90640_I2CRead(slaveAddr, MLX90640_CTRL_REG, 1, &controlRegister1);
+    if(error == 0){
+        value = (controlRegister1 & ~MLX90640_CTRL_DEVICE_MODE_MASK) | value;
+        error = MLX90640_I2CWrite(slaveAddr, MLX90640_CTRL_REG, value);
+    }
+
+    return error;
+}
+
+//------------------------------------------------------------------------------
+
 void MLX90640_CalculateTo(uint16_t *frameData, const paramsMLX90640 *params, float emissivity, float tr, float *result)
 {
     float vdd;

--- a/headers/MLX90640_API.h
+++ b/headers/MLX90640_API.h
@@ -56,6 +56,9 @@
 #define MLX90640_CTRL_RESOLUTION_MASK REG_MASK(MLX90640_CTRL_RESOLUTION_SHIFT,2)
 #define MLX90640_CTRL_MEAS_MODE_SHIFT 12
 #define MLX90640_CTRL_MEAS_MODE_MASK BIT_MASK(12)
+#define MLX90640_CTRL_SUBPAGE_REPEAT_MASK BIT_MASK(3)
+#define MLX90640_CTRL_SUBPAGE_MASK REG_MASK(4,3)
+#define MLX90640_CTRL_DEVICE_MODE_MASK BIT_MASK(1)
 
 #define MLX90640_MS_BYTE_SHIFT 8
 #define MLX90640_MS_BYTE_MASK 0xFF00
@@ -126,5 +129,8 @@ typedef struct
     int MLX90640_SetInterleavedMode(uint8_t slaveAddr);
     int MLX90640_SetChessMode(uint8_t slaveAddr);
     void MLX90640_BadPixelsCorrection(uint16_t *pixels, float *to, int mode, paramsMLX90640 *params);
-    
+    int MLX90640_SetSubPageRepeat(uint8_t slaveAddr, uint8_t subPageRepeat);
+    int MLX90640_SetSubPage(uint8_t slaveAddr, uint8_t subPage);
+    int MLX90640_SetDeviceMode(uint8_t slaveAddr, uint8_t deviceMode);
+
 #endif


### PR DESCRIPTION
Implement SetSubPageRepeat, SetSubPage, and SetDeviceMode based on datasheet register definitions. Similar changes are also present in in the @pimoroni mlx90640-library fork
(https://github.com/pimoroni/mlx90640-library).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new configuration functions to control MLX90640 device settings for sub-page repeat mode, sub-page selection, and device operating mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/melexis/mlx90640-library/pull/131)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->